### PR TITLE
Fixes halted uploading

### DIFF
--- a/python/tk_shotgun_submitFilesQTDialog/dialog.py
+++ b/python/tk_shotgun_submitFilesQTDialog/dialog.py
@@ -579,7 +579,8 @@ class Dialog(QtGui.QDialog):
             if version['sg_path_to_frames'] != None :
                 allVersionPaths.append(version['sg_path_to_frames'])
         for publishedFile in existingPublishes :
-            if publishedFile['path']['local_path'] != None :
+            path = publishedFile['path']
+            if path.get('local_path') is not None:
                 allPublishPaths.append(publishedFile['path']['local_path'])
 
         #Remove duplicates


### PR DESCRIPTION
Fix provided by Shotgun Software, this fixes not being able to submit if
there are published files found that are "uploads" instead of "local".

When trying to upload the submitter would not continue on the "sumit" page if there where "uploads" found in the versions/published files rather than "local" file links.